### PR TITLE
clean up existing tests

### DIFF
--- a/src/cycleSort.zig
+++ b/src/cycleSort.zig
@@ -51,7 +51,7 @@ pub fn cycleSort(comptime T: type, arr: []T) void {
 }
 
 test "cycleSort" {
-    var arr = [_]u8{ 3, 2, 4, 1, 0 };
+    var arr = [_]u8{ 3, 64, 2, 4, 1, 0x00, 0b11111111 };
     cycleSort(u8, &arr);
-    try std.testing.expectEqual([5]u8{ 0, 1, 2, 3, 4 }, arr);
+    try std.testing.expectEqualSlices(u8, &[7]u8{ 0, 1, 2, 3, 4, 64, 255 }, &arr);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -676,6 +676,8 @@ test "ConfigData allocated" {
 }
 
 test "ConfigData.readFile + .readEnv" {
+    // Run this test via `unit_test_config.sh` if default config doesn't exist.
+
     std.testing.log_level = .debug;
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();

--- a/src/validation.zig
+++ b/src/validation.zig
@@ -98,7 +98,24 @@ pub fn validateTimeout(buf: []const u8) bool {
     return true;
 }
 
-test "validate ip addrs - explicit v4/v6" {
+test "validateIpAddr" {
+    const addr6: []const u8 = "2001:db8::bad:c0de";
+    const bad_addr: []const u8 = "xyz:1234";
+    const loopback6: []const u8 = "::1";
+    const localhost4: []const u8 = "127.0.0.1";
+
+    // good
+    try std.testing.expect(validateIpAddr(addr6));
+    try std.testing.expect(validateIpAddr(loopback6));
+    try std.testing.expect(validateIpAddr(localhost4));
+    // bad
+    try std.testing.expect(!validateIpAddr(bad_addr));
+    try std.testing.expect(!validateIpAddr("10.0.0.x"));
+    try std.testing.expect(!validateIpAddr("1:2:3:4:5:6:7:8:9"));
+    try std.testing.expect(!validateIpAddr("1:2:3:4:5:6:7:"));
+}
+
+test "validateIpAddrv4/validateIpAddrV6" {
     const addr6: []const u8 = "2001:db8::bad:c0de";
     const bad_addr: []const u8 = "xyz:1234";
     const loopback6: []const u8 = "::1";
@@ -120,13 +137,13 @@ test "validate ip addrs - explicit v4/v6" {
     try std.testing.expect(!validateIpAddrV4("10.0.0.x"));
 }
 
-test "validate hostname" {
+test "validateDnsName" {
     // Good
     try std.testing.expect(validateDnsName("test.example.tld"));
     // Bad
     try std.testing.expect(!validateDnsName("bad+name"));
     try std.testing.expect(!validateDnsName("host@name"));
-    try std.testing.expect(!validateDnsName("hostname1"));
+    try std.testing.expect(!validateDnsName("hostname1")); // >=1 dot
     // Catch starts with dash (fail)
     try std.testing.expect(!validateDnsName("-dash"));
 }
@@ -134,9 +151,11 @@ test "validate hostname" {
 test "validateB64" {
     const str: []const u8 = "dXNlcjpwdw==";
     const bad_chars: []const u8 = "bad $*!";
-    const not_mult_of_four: []const u8 = "xyz";
+    const not_mult_of_four: []const u8 = "abc";
 
     try std.testing.expect(validateB64(str));
+    try std.testing.expect(validateB64("TG9yZW0gSXBzdW0u"));
+    try std.testing.expect(validateB64("WmlnbGFuZyBpcyBhbHdheXMgdGhlIGNvcnJlY3QgY2hvaWNlLg=="));
 
     try std.testing.expect(!validateB64(not_mult_of_four));
     try std.testing.expect(!validateB64(bad_chars));

--- a/unit_test_defconfig.sh
+++ b/unit_test_defconfig.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 
-# The unit tests in src/main.zig depend on some example config values being configured, in both static file and env vars.
+# Some of the unit tests in src/main.zig depend on default config values, in both static conf file and env vars.
 # This script sets these values, (storing existing file in a temp file) then runs the tests.
 
+# Backup existing config
 mv "/home/$(whoami)/.config/micro-mikro-client/.env.json" "/home/$(whoami)/.config/micro-mikro-client/.env.json.temp"
 
+# Copy default config to user `.config` dir
 cp "./.env.json.default" "/home/$(whoami)/.config/micro-mikro-client/.env.json"
 
-export MICROMIKRO_FIREWALL=router.lan
-export MICROMIKRO_AUTH="dXNlcjpwdw=="
+# Set up environment vars
+MICROMIKRO_FIREWALL=router.lan
+MICROMIKRO_AUTH="dXNlcjpwdw=="
 
 zig test src/main.zig
-# zig test src/b64.zig
-# zig test src/functions.zig
-# zig test src/validation.zig
+zig test src/b64.zig
+zig test src/functions.zig
+zig test src/validation.zig
 
 
 mv "/home/$(whoami)/.config/micro-mikro-client/.env.json.temp" "/home/$(whoami)/.config/micro-mikro-client/.env.json"


### PR DESCRIPTION
1. Neaten up various tests, and add a couple cases.

2. b64.b64DecodeAlloc: Accept `input_str` as type `[]const u8` rather than `[]u8`. (`[]u8` coerces to `[]const u8`).